### PR TITLE
Corrección CertifiedRoles

### DIFF
--- a/src/main/java/es/uji/crypto/xades/jxades/security/xml/XAdES/SignerRoleDetails.java
+++ b/src/main/java/es/uji/crypto/xades/jxades/security/xml/XAdES/SignerRoleDetails.java
@@ -28,7 +28,7 @@ public class SignerRoleDetails extends XAdESStructure
         super(document, ssp, "SignerRole", xadesPrefix, xadesNamespace, xmlSignaturePrefix);
 
         Element claimedRoles = createElement("ClaimedRoles");
-        Element certifiedRoles = createElement("ClaimedRoles");
+        Element certifiedRoles = createElement("CertifiedRoles");
 
         for (String sr : signerRole.getClaimedRole())
         {


### PR DESCRIPTION
- El nodo `<CertifiedRoles>` del `<SignerRole>` se escribía como `<ClaimedRoles>`.