### PR TITLE
Soporte de generación baseline B-Level

### DIFF
--- a/src/main/java/es/uji/crypto/xades/jxades/security/xml/XAdES/BLevelXAdESImpl.java
+++ b/src/main/java/es/uji/crypto/xades/jxades/security/xml/XAdES/BLevelXAdESImpl.java
@@ -3,7 +3,6 @@ package es.uji.crypto.xades.jxades.security.xml.XAdES;
 import java.security.GeneralSecurityException;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 import java.util.TreeMap;
@@ -84,9 +83,9 @@ public class BLevelXAdESImpl extends BaseXAdESImpl implements XAdES_B_Level
     }
 
     @Override
-	public SignatureProductionPlace getSignatureProductionPlace()
+	public SignatureProductionPlaceV2 getSignatureProductionPlaceV2()
     {
-        return (SignatureProductionPlace) this.data.get(XAdES.Element.SIGNATURE_PRODUCTION_PLACE);
+        return (SignatureProductionPlaceV2) this.data.get(XAdES.Element.SIGNATURE_PRODUCTION_PLACE_V2);
     }
 
     @Override
@@ -174,16 +173,16 @@ public class BLevelXAdESImpl extends BaseXAdESImpl implements XAdES_B_Level
     }
 
     @Override
-	public void setSignatureProductionPlace(final SignatureProductionPlace productionPlace)
+	public void setSignatureProductionPlaceV2(final SignatureProductionPlaceV2 productionPlace)
     {
         if (this.readOnlyMode) {
 			throw new UnsupportedOperationException("Set Method is not allowed. Read-only mode."); //$NON-NLS-1$
 		}
 
         if (productionPlace != null) {
-			this.data.put(XAdES.Element.SIGNATURE_PRODUCTION_PLACE, productionPlace);
+			this.data.put(XAdES.Element.SIGNATURE_PRODUCTION_PLACE_V2, productionPlace);
 		} else {
-			this.data.remove(XAdES.Element.SIGNATURE_PRODUCTION_PLACE);
+			this.data.remove(XAdES.Element.SIGNATURE_PRODUCTION_PLACE_V2);
 		}
     }
 
@@ -384,10 +383,10 @@ public class BLevelXAdESImpl extends BaseXAdESImpl implements XAdES_B_Level
                             ssp = getSignedSignatureProperties(qp);
                             ssp.setSignaturePolicyIdentifier((SignaturePolicyIdentifier) value);
                         }
-                        else if (XAdES.Element.SIGNATURE_PRODUCTION_PLACE.equals(key))
+                        else if (XAdES.Element.SIGNATURE_PRODUCTION_PLACE_V2.equals(key))
                         {
                             ssp = getSignedSignatureProperties(qp);
-                            ssp.setSignatureProductionPlace((SignatureProductionPlace) value);
+                            ssp.setSignatureProductionPlaceV2((SignatureProductionPlaceV2) value);
                         }
                         else if (XAdES.Element.SIGNER_ROLE_V2.equals(key))
                         {

--- a/src/main/java/es/uji/crypto/xades/jxades/security/xml/XAdES/BLevelXAdESImpl.java
+++ b/src/main/java/es/uji/crypto/xades/jxades/security/xml/XAdES/BLevelXAdESImpl.java
@@ -18,7 +18,7 @@ import org.w3c.dom.NodeList;
  *
  * @author miro
  */
-public class BasicXAdESImpl extends BaseXAdESImpl implements XAdES_BES
+public class BLevelXAdESImpl extends BaseXAdESImpl implements XAdES_B_Level
 {
     protected boolean readOnlyMode = true;
     protected TreeMap<XAdES.Element, Object> data;
@@ -31,7 +31,7 @@ public class BasicXAdESImpl extends BaseXAdESImpl implements XAdES_BES
     public String xmlSignaturePrefix;
     public String digestMethod;
 
-    public BasicXAdESImpl(final Document document, final Element baseElement, final boolean readOnlyMode,
+    public BLevelXAdESImpl(final Document document, final Element baseElement, final boolean readOnlyMode,
             final String xadesPrefix, final String xadesNamespace, final String xmlSignaturePrefix,
             final String digestMethod)
     {
@@ -78,9 +78,9 @@ public class BasicXAdESImpl extends BaseXAdESImpl implements XAdES_BES
     }
 
     @Override
-	public SigningCertificate getSigningCertificate()
+	public SigningCertificateV2 getSigningCertificateV2()
     {
-        return (SigningCertificate) this.data.get(XAdES.Element.SIGNING_CERTIFICATE);
+        return (SigningCertificateV2) this.data.get(XAdES.Element.SIGNING_CERTIFICATE_V2);
     }
 
     @Override
@@ -146,7 +146,7 @@ public class BasicXAdESImpl extends BaseXAdESImpl implements XAdES_BES
 	public void setSigningTime(final Date signingTime)
     {
         if (this.readOnlyMode) {
-			throw new UnsupportedOperationException("Set Method is not allowed. Read-only mode.");
+			throw new UnsupportedOperationException("Set Method is not allowed. Read-only mode."); //$NON-NLS-1$
 		}
 
         if (signingTime != null) {
@@ -157,24 +157,27 @@ public class BasicXAdESImpl extends BaseXAdESImpl implements XAdES_BES
     }
 
     @Override
-    public void setSigningCertificate(X509Certificate certificate) {
+	public void setSigningCertificateV2(X509Certificate signingCertificate, SigningCertificateV2Info additionalInfo)
+    {
         if (this.readOnlyMode) {
-			throw new UnsupportedOperationException("Set Method is not allowed. Read-only mode.");
+			throw new UnsupportedOperationException("Set Method is not allowed. Read-only mode."); //$NON-NLS-1$
 		}
 
-        if (certificate == null) {
-        	this.data.remove(XAdES.Element.SIGNING_CERTIFICATE);
-		} else {
-			final SigningCertificateImpl sci = new SigningCertificateImpl(certificate, this.digestMethod);
-			this.data.put(XAdES.Element.SIGNING_CERTIFICATE, sci);
+        if (signingCertificate == null) {
+        	this.data.remove(XAdES.Element.SIGNING_CERTIFICATE_V2);
 		}
+        else {
+        	final SigningCertificateV2Impl sci = new SigningCertificateV2Impl(signingCertificate, this.digestMethod);
+        	sci.setIssuerSerialV2(additionalInfo != null ? additionalInfo.getIssuerSerialV2() : null);
+        	this.data.put(XAdES.Element.SIGNING_CERTIFICATE_V2, sci);
+        }
     }
-    
+
     @Override
 	public void setSignatureProductionPlace(final SignatureProductionPlace productionPlace)
     {
         if (this.readOnlyMode) {
-			throw new UnsupportedOperationException("Set Method is not allowed. Read-only mode.");
+			throw new UnsupportedOperationException("Set Method is not allowed. Read-only mode."); //$NON-NLS-1$
 		}
 
         if (productionPlace != null) {
@@ -188,7 +191,7 @@ public class BasicXAdESImpl extends BaseXAdESImpl implements XAdES_BES
 	public void setSignerRole(final SignerRole signerRole)
     {
         if (this.readOnlyMode) {
-			throw new UnsupportedOperationException("Set Method is not allowed. Read-only mode.");
+			throw new UnsupportedOperationException("Set Method is not allowed. Read-only mode."); //$NON-NLS-1$
 		}
 
         if (signerRole != null) {
@@ -202,7 +205,7 @@ public class BasicXAdESImpl extends BaseXAdESImpl implements XAdES_BES
 	public void setSigner(final Signer signer)
     {
         if (this.readOnlyMode) {
-			throw new UnsupportedOperationException("Set Method is not allowed. Read-only mode.");
+			throw new UnsupportedOperationException("Set Method is not allowed. Read-only mode."); //$NON-NLS-1$
 		}
 
         if (signer != null) {
@@ -216,7 +219,7 @@ public class BasicXAdESImpl extends BaseXAdESImpl implements XAdES_BES
 	public void setDataObjectFormats(final List<DataObjectFormat> dataObjectFormats)
     {
         if (this.readOnlyMode) {
-			throw new UnsupportedOperationException("Set Method is not allowed. Read-only mode.");
+			throw new UnsupportedOperationException("Set Method is not allowed. Read-only mode."); //$NON-NLS-1$
 		}
 
         if (dataObjectFormats != null && dataObjectFormats.size() > 0) {
@@ -231,7 +234,7 @@ public class BasicXAdESImpl extends BaseXAdESImpl implements XAdES_BES
             final List<CommitmentTypeIndication> commitmentTypeIndications)
     {
         if (this.readOnlyMode) {
-			throw new UnsupportedOperationException("Set Method is not allowed. Read-only mode.");
+			throw new UnsupportedOperationException("Set Method is not allowed. Read-only mode."); //$NON-NLS-1$
 		}
 
         if (commitmentTypeIndications != null && commitmentTypeIndications.size() > 0) {
@@ -245,7 +248,7 @@ public class BasicXAdESImpl extends BaseXAdESImpl implements XAdES_BES
 	public void setAllDataObjectsTimeStamps(final List<AllDataObjectsTimeStamp> allDataObjectsTimeStamps)
     {
         if (this.readOnlyMode) {
-			throw new UnsupportedOperationException("Set Method is not allowed. Read-only mode.");
+			throw new UnsupportedOperationException("Set Method is not allowed. Read-only mode."); //$NON-NLS-1$
 		}
 
         if (allDataObjectsTimeStamps != null && allDataObjectsTimeStamps.size() > 0) {
@@ -260,7 +263,7 @@ public class BasicXAdESImpl extends BaseXAdESImpl implements XAdES_BES
             final List<IndividualDataObjectsTimeStamp> individualDataObjectsTimeStamps)
     {
         if (this.readOnlyMode) {
-			throw new UnsupportedOperationException("Set Method is not allowed. Read-only mode.");
+			throw new UnsupportedOperationException("Set Method is not allowed. Read-only mode."); //$NON-NLS-1$
 		}
 
         if (individualDataObjectsTimeStamps != null && individualDataObjectsTimeStamps.size() > 0) {
@@ -275,7 +278,7 @@ public class BasicXAdESImpl extends BaseXAdESImpl implements XAdES_BES
 	public void setCounterSignatures(final List<CounterSignature> counterSignatures)
     {
         if (this.readOnlyMode) {
-			throw new UnsupportedOperationException("Set Method is not allowed. Read-only mode.");
+			throw new UnsupportedOperationException("Set Method is not allowed. Read-only mode."); //$NON-NLS-1$
 		}
 
         if (counterSignatures != null && counterSignatures.size() > 0) {
@@ -289,7 +292,7 @@ public class BasicXAdESImpl extends BaseXAdESImpl implements XAdES_BES
     {
         if (this.readOnlyMode)
         {
-            throw new UnsupportedOperationException("Set Method is not allowed. Read-only mode.");
+            throw new UnsupportedOperationException("Set Method is not allowed. Read-only mode."); //$NON-NLS-1$
         }
 
         if (signatureTimeStamps != null && signatureTimeStamps.size() > 0)
@@ -302,29 +305,12 @@ public class BasicXAdESImpl extends BaseXAdESImpl implements XAdES_BES
         }
     }
 
-    // public void setCompleteCertificateRefs(Collection<X509Certificate> caCertificates)
-    // {
-    // if (readOnlyMode)
-    // {
-    // throw new UnsupportedOperationException("Set Method is not allowed. Read-only mode.");
-    // }
-    //
-    // if (caCertificates != null && caCertificates.size() > 0)
-    // {
-    // data.put(XAdES.Element.COMPLETE_CERTIFICATE_REFS, caCertificates);
-    // }
-    // else
-    // {
-    // data.remove(XAdES.Element.COMPLETE_CERTIFICATE_REFS);
-    // }
-    // }
-
     // Each implementation have to inherit this method
     // and to return the appropriate XAdES type.
     // This is important for checking cases in new XML Advanced Signature
     protected XAdES getXAdESType()
     {
-        return XAdES.BES;
+        return XAdES.B_LEVEL;
     }
 
     protected QualifyingProperties getQualifyingProperties()
@@ -343,17 +329,20 @@ public class BasicXAdESImpl extends BaseXAdESImpl implements XAdES_BES
         return this.qualifyingProperties;
     }
 
-    protected SignedSignatureProperties getSignedSignatureProperties(final QualifyingProperties qp)
+    @SuppressWarnings("static-method")
+	protected SignedSignatureProperties getSignedSignatureProperties(final QualifyingProperties qp)
     {
         return qp.getSignedProperties().getSignedSignatureProperties();
     }
 
-    protected SignedDataObjectProperties getSignedDataObjectProperties(final QualifyingProperties qp)
+    @SuppressWarnings("static-method")
+	protected SignedDataObjectProperties getSignedDataObjectProperties(final QualifyingProperties qp)
     {
         return qp.getSignedProperties().getSignedDataObjectProperties();
     }
 
-    protected UnsignedSignatureProperties getUnsignedSignatureProperties(final QualifyingProperties qp)
+    @SuppressWarnings("static-method")
+	protected UnsignedSignatureProperties getUnsignedSignatureProperties(final QualifyingProperties qp)
     {
         return qp.getUnsignedProperties().getUnsignedSignatureProperties();
     }
@@ -364,7 +353,6 @@ public class BasicXAdESImpl extends BaseXAdESImpl implements XAdES_BES
     {
         SignedSignatureProperties ssp;
         SignedDataObjectProperties sdop;
-        UnsignedSignatureProperties usp;
 
         try
         {
@@ -386,10 +374,10 @@ public class BasicXAdESImpl extends BaseXAdESImpl implements XAdES_BES
                             ssp = getSignedSignatureProperties(qp);
                             ssp.setSigner((Signer) value);
                         }
-                        else if (XAdES.Element.SIGNING_CERTIFICATE.equals(key))
+                        else if (XAdES.Element.SIGNING_CERTIFICATE_V2.equals(key))
                         {
                             ssp = getSignedSignatureProperties(qp);
-                            ssp.setSigningCertificate((SigningCertificate) value);
+                            ssp.setSigningCertificateV2((SigningCertificateV2) value);
                         }
                         else if (XAdES.Element.SIGNATURE_POLICY_IDENTIFIER.equals(key))
                         {
@@ -417,12 +405,6 @@ public class BasicXAdESImpl extends BaseXAdESImpl implements XAdES_BES
                             sdop = getSignedDataObjectProperties(qp);
                             sdop.setCommitmentTypeIndications((ArrayList<CommitmentTypeIndication>) value);
                         }
-                        else if (XAdES.Element.COMPLETE_CERTIFICATE_REFS.equals(key))
-                        {
-                            usp = getUnsignedSignatureProperties(qp);
-                            usp.setCompleteCertificateRefs((Collection<X509Certificate>) value,
-                                    signatureIdPrefix);
-                        }
                     }
                 }
             }
@@ -449,5 +431,29 @@ public class BasicXAdESImpl extends BaseXAdESImpl implements XAdES_BES
 	public String getXadesNamespace()
     {
         return this.xadesNamespace;
+    }
+    
+    @Override
+	public void setSignaturePolicyIdentifier(SignaturePolicyIdentifier signaturePolicyIdentifier)
+    {
+        if (this.readOnlyMode)
+        {
+            throw new UnsupportedOperationException("Set Method is not allowed. Read-only mode."); //$NON-NLS-1$
+        }
+
+        if (signaturePolicyIdentifier != null)
+        {
+            this.data.put(XAdES.Element.SIGNATURE_POLICY_IDENTIFIER, signaturePolicyIdentifier);
+        }
+        else
+        {
+            this.data.remove(XAdES.Element.SIGNATURE_POLICY_IDENTIFIER);
+        }
+    }
+
+    @Override
+	public SignaturePolicyIdentifier getSignaturePolicyIdentifier()
+    {
+        return (SignaturePolicyIdentifier) this.data.get(XAdES.Element.SIGNATURE_POLICY_IDENTIFIER);
     }
 }

--- a/src/main/java/es/uji/crypto/xades/jxades/security/xml/XAdES/BLevelXAdESImpl.java
+++ b/src/main/java/es/uji/crypto/xades/jxades/security/xml/XAdES/BLevelXAdESImpl.java
@@ -90,9 +90,9 @@ public class BLevelXAdESImpl extends BaseXAdESImpl implements XAdES_B_Level
     }
 
     @Override
-	public SignerRole getSignerRole()
+	public SignerRoleV2 getSignerRoleV2()
     {
-        return (SignerRole) this.data.get(XAdES.Element.SIGNER_ROLE);
+        return (SignerRoleV2) this.data.get(XAdES.Element.SIGNER_ROLE_V2);
     }
 
     @Override
@@ -188,16 +188,16 @@ public class BLevelXAdESImpl extends BaseXAdESImpl implements XAdES_B_Level
     }
 
     @Override
-	public void setSignerRole(final SignerRole signerRole)
+	public void setSignerRoleV2(final SignerRoleV2 signerRole)
     {
         if (this.readOnlyMode) {
 			throw new UnsupportedOperationException("Set Method is not allowed. Read-only mode."); //$NON-NLS-1$
 		}
 
         if (signerRole != null) {
-			this.data.put(XAdES.Element.SIGNER_ROLE, signerRole);
+			this.data.put(XAdES.Element.SIGNER_ROLE_V2, signerRole);
 		} else {
-			this.data.remove(XAdES.Element.SIGNER_ROLE);
+			this.data.remove(XAdES.Element.SIGNER_ROLE_V2);
 		}
     }
 
@@ -389,10 +389,10 @@ public class BLevelXAdESImpl extends BaseXAdESImpl implements XAdES_B_Level
                             ssp = getSignedSignatureProperties(qp);
                             ssp.setSignatureProductionPlace((SignatureProductionPlace) value);
                         }
-                        else if (XAdES.Element.SIGNER_ROLE.equals(key))
+                        else if (XAdES.Element.SIGNER_ROLE_V2.equals(key))
                         {
                             ssp = getSignedSignatureProperties(qp);
-                            ssp.setSignerRole((SignerRole) value);
+                            ssp.setSignerRoleV2((SignerRoleV2) value);
                         }
                         else if (XAdES.Element.DATA_OBJECT_FORMATS.equals(key))
                         {

--- a/src/main/java/es/uji/crypto/xades/jxades/security/xml/XAdES/BaseXAdESImpl.java
+++ b/src/main/java/es/uji/crypto/xades/jxades/security/xml/XAdES/BaseXAdESImpl.java
@@ -1,0 +1,15 @@
+package es.uji.crypto.xades.jxades.security.xml.XAdES;
+
+import java.util.List;
+
+import javax.xml.crypto.MarshalException;
+
+/**
+ * The minimun methods needed to sign a XAdES implementation. 
+ */
+public abstract class BaseXAdESImpl implements XAdESBase {
+
+	
+	protected abstract void marshalQualifyingProperties(final QualifyingProperties qp, final String signatureIdPrefix,
+            final List referencesIdList) throws MarshalException;
+}

--- a/src/main/java/es/uji/crypto/xades/jxades/security/xml/XAdES/SignatureProductionPlaceV2.java
+++ b/src/main/java/es/uji/crypto/xades/jxades/security/xml/XAdES/SignatureProductionPlaceV2.java
@@ -1,0 +1,8 @@
+package es.uji.crypto.xades.jxades.security.xml.XAdES;
+
+public interface SignatureProductionPlaceV2 extends SignatureProductionPlace
+{
+	public void setStreetAddress(String streetAddress);
+	
+	public String getStreetAddress();
+}

--- a/src/main/java/es/uji/crypto/xades/jxades/security/xml/XAdES/SignatureProductionPlaceV2Details.java
+++ b/src/main/java/es/uji/crypto/xades/jxades/security/xml/XAdES/SignatureProductionPlaceV2Details.java
@@ -1,0 +1,71 @@
+package es.uji.crypto.xades.jxades.security.xml.XAdES;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+
+/**
+ * Sample usage of signing SignatureProductionPlaceV2:
+ * <p>
+ * {@code
+ * <xades:SignatureProductionPlace>
+ *     <xades:City>City</xades:City>
+ *     <xades:StreetAddress>StreetAddress</xades:StreetAddress>
+ *     <xades:StateOrProvince>StateOrProvince</xades:StateOrProvince>
+ *     <xades:PostalCode>PostalCode</xades:PostalCode>
+ *     <xades:CountryName>CountryName</xades:CountryName>
+ * </xades:SignatureProductionPlace>
+ * }
+ * </p>
+ */
+public class SignatureProductionPlaceV2Details extends XAdESStructure
+{
+    public SignatureProductionPlaceV2Details(Document document, SignedSignatureProperties ssp,
+            SignatureProductionPlaceV2 signatureProductionPlace, String xadesPrefix,
+            String xadesNamespace, String xmlSignaturePrefix)
+    {
+        super(document, ssp, "SignatureProductionPlaceV2", xadesPrefix, xadesNamespace,
+                xmlSignaturePrefix);
+
+        if (signatureProductionPlace.getCity() != null)
+        {
+            Element city = createElement("City");
+            city.setTextContent(signatureProductionPlace.getCity());
+            getNode().appendChild(city);
+        }
+
+        if (signatureProductionPlace.getStreetAddress() != null)
+        {
+            Element streetAddress = createElement("StreetAddress");
+            streetAddress.setTextContent(signatureProductionPlace.getStreetAddress());
+            getNode().appendChild(streetAddress);
+        }
+
+        if (signatureProductionPlace.getStateOrProvince() != null)
+        {
+            Element stateOrProvince = createElement("StateOrProvince");
+            stateOrProvince.setTextContent(signatureProductionPlace.getStateOrProvince());
+            getNode().appendChild(stateOrProvince);
+        }
+
+        if (signatureProductionPlace.getPostalCode() != null)
+        {
+            Element postalCode = createElement("PostalCode");
+            postalCode.setTextContent(signatureProductionPlace.getPostalCode());
+            getNode().appendChild(postalCode);
+        }
+
+        if (signatureProductionPlace.getCountryName() != null)
+        {
+            Element countryName = createElement("CountryName");
+            countryName.setTextContent(signatureProductionPlace.getCountryName());
+            getNode().appendChild(countryName);
+        }
+    }
+
+    public SignatureProductionPlaceV2Details(Node node, String xadesPrefix, String xadesNamespace,
+            String xmlSignaturePrefix)
+    {
+        super(node, xadesPrefix, xadesNamespace, xmlSignaturePrefix);
+    }
+}

--- a/src/main/java/es/uji/crypto/xades/jxades/security/xml/XAdES/SignatureProductionPlaceV2Impl.java
+++ b/src/main/java/es/uji/crypto/xades/jxades/security/xml/XAdES/SignatureProductionPlaceV2Impl.java
@@ -1,0 +1,28 @@
+package es.uji.crypto.xades.jxades.security.xml.XAdES;
+
+public class SignatureProductionPlaceV2Impl extends SignatureProductionPlaceImpl
+implements SignatureProductionPlaceV2
+{
+	private String streetAddress;
+
+	public SignatureProductionPlaceV2Impl() 
+	{
+		super();
+	}
+
+	public SignatureProductionPlaceV2Impl(String city, String streetAddress, String stateOrProvince, String postalCode, String countryName) 
+	{
+		super(city, stateOrProvince, postalCode, countryName);
+		this.streetAddress = streetAddress;
+	}
+	
+	public String getStreetAddress()
+	{
+		return this.streetAddress;
+	}
+
+	public void setStreetAddress(String streetAddress)
+	{
+		this.streetAddress = streetAddress;
+	}
+}

--- a/src/main/java/es/uji/crypto/xades/jxades/security/xml/XAdES/SignedProperties.java
+++ b/src/main/java/es/uji/crypto/xades/jxades/security/xml/XAdES/SignedProperties.java
@@ -9,8 +9,10 @@ import org.w3c.dom.Node;
  *   <SignedSignatureProperties>
  *     (SigningTime)?
  *     (SigningCertificate)?
+ *     (SigningCertificateV2)?
  *     (SignatureProductionPlace)?
  *     (SignerRole)?
+ *     (SignerRoleV2)?
  *   </SignedSignatureProperties>
  *   <SignedDataObjectProperties>
  *     (DataObjectFormat)*

--- a/src/main/java/es/uji/crypto/xades/jxades/security/xml/XAdES/SignedSignatureProperties.java
+++ b/src/main/java/es/uji/crypto/xades/jxades/security/xml/XAdES/SignedSignatureProperties.java
@@ -131,6 +131,15 @@ public class SignedSignatureProperties extends XAdESStructure
                     this.xadesNamespace, this.xmlSignaturePrefix);
         }
     }
+    
+    public void setSignatureProductionPlaceV2(final SignatureProductionPlaceV2 signatureProductionPlace)
+    {
+        if (signatureProductionPlace != null)
+        {
+            new SignatureProductionPlaceV2Details(this.document, this, signatureProductionPlace, this.xadesPrefix,
+                    this.xadesNamespace, this.xmlSignaturePrefix);
+        }
+    }
 
     public void setSignaturePolicyIdentifier(final SignaturePolicyIdentifier signaturePolicyIdentifier)
     {

--- a/src/main/java/es/uji/crypto/xades/jxades/security/xml/XAdES/SignedSignatureProperties.java
+++ b/src/main/java/es/uji/crypto/xades/jxades/security/xml/XAdES/SignedSignatureProperties.java
@@ -11,28 +11,32 @@ import org.w3c.dom.Node;
  <SignedSignatureProperties>
  (SigningTime)?
  (SigningCertificate)?
+ (SigningCertificateV2)?
+ (SignaturePolicyIdentifier)?
  (SignatureProductionPlace)?
+ (SignatureProductionPlaceV2)?
  (SignerRole)?
+ (SignerRoleV2)?
  </SignedSignatureProperties>
  */
 
 /**
- * 
+ *
  * @author miro
  */
 public class SignedSignatureProperties extends XAdESStructure
 {
     private Document document;
 
-    public SignedSignatureProperties(Document document, SignedProperties sp, String xadesPrefix,
-            String xadesNamespace, String xmlSignaturePrefix)
+    public SignedSignatureProperties(final Document document, final SignedProperties sp, final String xadesPrefix,
+            final String xadesNamespace, final String xmlSignaturePrefix)
     {
         super(document, sp, "SignedSignatureProperties", xadesPrefix, xadesNamespace, xmlSignaturePrefix);
         this.document = document;
     }
 
-    public SignedSignatureProperties(Node node, String xadesPrefix, String xadesNamespace,
-            String xmlSignaturePrefix)
+    public SignedSignatureProperties(final Node node, final String xadesPrefix, final String xadesNamespace,
+            final String xmlSignaturePrefix)
     {
         super(node, xadesPrefix, xadesNamespace, xmlSignaturePrefix);
     }
@@ -42,44 +46,54 @@ public class SignedSignatureProperties extends XAdESStructure
         setSigningTime(new Date());
     }
 
-    public void setSigningTime(Date signingTime)
+    public void setSigningTime(final Date signingTime)
     {
-        new SigningTime(document, this, signingTime, xadesPrefix, xadesNamespace, xmlSignaturePrefix);
+        new SigningTime(this.document, this, signingTime, this.xadesPrefix, this.xadesNamespace, this.xmlSignaturePrefix);
     }
 
-    public void setSigner(Signer signer)
+    public void setSigner(final Signer signer)
     {
-        new SignerDetails(document, this, signer, xadesPrefix, xadesNamespace, xmlSignaturePrefix);
+        new SignerDetails(this.document, this, signer, this.xadesPrefix, this.xadesNamespace, this.xmlSignaturePrefix);
     }
 
-    public void setSigningCertificate(SigningCertificate signingCertificate)
+    public void setSigningCertificate(final SigningCertificate signingCertificate)
             throws GeneralSecurityException
     {
         if (signingCertificate != null)
         {
-            new SigningCertificateDetails(document, this, signingCertificate, xadesPrefix, xadesNamespace,
-                    xmlSignaturePrefix);
+            new SigningCertificateDetails(this.document, this, signingCertificate, this.xadesPrefix, this.xadesNamespace,
+                    this.xmlSignaturePrefix);
         }
     }
 
-    public void setSignerRole(SignerRole signerRole)
+    public void setSigningCertificateV2(final SigningCertificateV2 signingCertificateV2)
+            throws GeneralSecurityException
+    {
+        if (signingCertificateV2 != null)
+        {
+            new SigningCertificateV2Details(this.document, this, signingCertificateV2, this.xadesPrefix, this.xadesNamespace,
+                    this.xmlSignaturePrefix);
+        }
+    }
+
+    public void setSignerRole(final SignerRole signerRole)
     {
         if (signerRole != null)
         {
             if (signerRole.getClaimedRole().size() > 0 || signerRole.getCertifiedRole().size() > 0)
             {
-                new SignerRoleDetails(document, this, signerRole, xadesPrefix, xadesNamespace,
-                        xmlSignaturePrefix);
+                new SignerRoleDetails(this.document, this, signerRole, this.xadesPrefix, this.xadesNamespace,
+                        this.xmlSignaturePrefix);
             }
         }
     }
 
     public Signer getSigner()
     {
-        SignerDetails details = getSignerDetails();
+        final SignerDetails details = getSignerDetails();
         if (details != null)
         {
-            Signer signer = details.getSigner();
+            final Signer signer = details.getSigner();
             return signer;
         }
 
@@ -88,28 +102,29 @@ public class SignedSignatureProperties extends XAdESStructure
 
     protected SignerDetails getSignerDetails()
     {
-        Element element = getChildElementNS("SignerDetails");
-        if (element != null)
-            return new SignerDetails(element, xadesPrefix, xadesNamespace, xmlSignaturePrefix);
-        else
-            return null;
+        final Element element = getChildElementNS("SignerDetails");
+        if (element != null) {
+			return new SignerDetails(element, this.xadesPrefix, this.xadesNamespace, this.xmlSignaturePrefix);
+		} else {
+			return null;
+		}
     }
 
-    public void setSignatureProductionPlace(SignatureProductionPlace signatureProductionPlace)
+    public void setSignatureProductionPlace(final SignatureProductionPlace signatureProductionPlace)
     {
         if (signatureProductionPlace != null)
         {
-            new SignatureProductionPlaceDetails(document, this, signatureProductionPlace, xadesPrefix,
-                    xadesNamespace, xmlSignaturePrefix);
+            new SignatureProductionPlaceDetails(this.document, this, signatureProductionPlace, this.xadesPrefix,
+                    this.xadesNamespace, this.xmlSignaturePrefix);
         }
     }
 
-    public void setSignaturePolicyIdentifier(SignaturePolicyIdentifier signaturePolicyIdentifier)
+    public void setSignaturePolicyIdentifier(final SignaturePolicyIdentifier signaturePolicyIdentifier)
     {
         if (signaturePolicyIdentifier != null)
         {
-            new SignaturePolicyIdentifierDetails(document, this, signaturePolicyIdentifier, xadesPrefix,
-                    xadesNamespace, xmlSignaturePrefix);
+            new SignaturePolicyIdentifierDetails(this.document, this, signaturePolicyIdentifier, this.xadesPrefix,
+                    this.xadesNamespace, this.xmlSignaturePrefix);
         }
     }
 }

--- a/src/main/java/es/uji/crypto/xades/jxades/security/xml/XAdES/SignedSignatureProperties.java
+++ b/src/main/java/es/uji/crypto/xades/jxades/security/xml/XAdES/SignedSignatureProperties.java
@@ -87,6 +87,19 @@ public class SignedSignatureProperties extends XAdESStructure
             }
         }
     }
+    
+    public void setSignerRoleV2(final SignerRoleV2 signerRole)
+    {
+        if (signerRole != null)
+        {
+            if (signerRole.getClaimedRoles().size() > 0 || signerRole.getCertifiedRolesV2().size() > 0
+            		 || signerRole.getSignedAssertions().size() > 0)
+            {
+                new SignerRoleV2Details(this.document, this, signerRole, this.xadesPrefix,
+                		this.xadesNamespace, this.xmlSignaturePrefix);
+            }
+        }
+    }
 
     public Signer getSigner()
     {

--- a/src/main/java/es/uji/crypto/xades/jxades/security/xml/XAdES/SignerRoleV2.java
+++ b/src/main/java/es/uji/crypto/xades/jxades/security/xml/XAdES/SignerRoleV2.java
@@ -1,0 +1,93 @@
+package es.uji.crypto.xades.jxades.security.xml.XAdES;
+
+import java.util.ArrayList;
+
+/**
+ * 5.2.6 The SignerRoleV2 qualifying property
+<p>Semantics</p>
+<p>The SignerRoleV2 qualifying property shall be a signed qualifying property that qualifies the signer.</p>
+<p>The SignerRoleV2 qualifying property shall encapsulate signer attributes (e.g. role). This qualifying property may
+encapsulate the following types of attributes:</p>
+<ul>
+<li>attributes claimed by the signer;</li>
+<li>attributes certified in attribute certificates issued by an Attribute Authority; or/and</li>
+<li>assertions signed by a third party.</li>
+</ul>
+<p>Syntax</p>
+<p>The SignerRoleV2 qualifying property shall be defined as in XML Schema file "XAdES01903v132-201601.xsd",
+whose location is detailed in clause C.1, and is copied below for information.</p>
+<code>
+    <!-- targetNamespace="http://uri.etsi.org/01903/v1.3.2#" -->
+    <xsd:element name="SignerRoleV2" type="SignerRoleV2Type"/>
+    <xsd:complexType name="SignerRoleV2Type">
+        <xsd:sequence>
+            <xsd:element ref="ClaimedRoles" minOccurs="0"/>
+            <xsd:element ref="CertifiedRolesV2" minOccurs="0"/>
+            <xsd:element ref="SignedAssertions" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:element name="ClaimedRoles" type="ClaimedRolesListType"/>
+    <xsd:element name="CertifiedRolesV2" type="CertifiedRolesListTypeV2"/>
+    <xsd:element name="SignedAssertions" type="SignedAssertionsListType"/>
+    <xsd:complexType name="ClaimedRolesListType">
+        <xsd:sequence>
+            <xsd:element name="ClaimedRole" type="AnyType" maxOccurs="unbounded"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="CertifiedRolesListTypeV2">
+        <xsd:sequence>
+            <xsd:element name="CertifiedRole" type="CertifiedRoleTypeV2" maxOccurs="unbounded"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="CertifiedRoleTypeV2">
+        <xsd:choice>
+            <xsd:element ref="X509AttributeCertificate"/>
+            <xsd:element ref="OtherAttributeCertificate"/>
+        </xsd:choice>
+    </xsd:complexType>
+    <xsd:element name="X509AttributeCertificate" type="EncapsulatedPKIDataType"/>
+    <xsd:element name="OtherAttributeCertificate" type="AnyType"/>
+    <xsd:complexType name="SignedAssertionsListType">
+        <xsd:sequence>
+            <xsd:element ref="SignedAssertion" maxOccurs="unbounded"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:element name="SignedAssertion" type="AnyType"/>
+</code>
+<p>The ClaimedRoles element shall contain a non-empty sequence of roles claimed by the signer but which are not
+certified.</p>
+<p>Additional content types may be defined on a domain application basis and be part of this element.</p>
+<p>NOTE 1: The namespaces given to the corresponding XML schemas allow their unambiguous identification in the
+case these attributes are expressed in XML syntax (e.g. SAML assertions [i.9] of different versions).</p>
+<p>The CertifiedRolesV2 element shall contain a non-empty sequence of certified attributes, which shall be one of
+the following:</p>
+<ul>
+    <li>the base-64 encoding of DER-encoded X509 attribute certificates conformant to Recommendation
+ITU-T X.509 [4] issued to the signer, within the X509AttributeCertificate element; or</li>
+    <li>attribute certificates (issued, in consequence, by Attribute Authorities) in different syntax than the one
+specified in Recommendation ITU-T X.509 [4], within the OtherAttributeCertificate element. The
+definition of specific OtherAttributeCertificate is outside of the scope of the present document.</li>
+</ul>
+<p>The SignedAssertions element shall contain a non-empty sequence of assertions signed by a third party.</p>
+<p>NOTE 2: A signed assertion is stronger than a claimed attribute, since a third party asserts with a signature that the
+attribute of the signer is valid. However, it is less restrictive than an attribute certificate.</p>
+<p>The definition of specific content types for SignedAssertions is outside of the scope of the present document.</p>
+<p>NOTE 3: A possible content can be a signed SAML [i.9] assertion.
+Empty SignerRoleV2 qualifying properties shall not be generated.</p>
+ *
+ *
+ * @author miro
+ */
+public interface SignerRoleV2
+{
+	public ArrayList<String> getClaimedRoles();
+	public void setClaimedRoles(ArrayList<String> claimedRole);
+	public void addClaimedRole(String role);
+		
+	public ArrayList<String> getCertifiedRolesV2();
+	public void setCertifiedRolesV2(ArrayList<String> certifiedRole);
+	public void addCertifiedRoleV2(String role);
+	
+	public ArrayList<String> getSignedAssertions();
+	public void setSignedAssertions(ArrayList<String> signedAssertions);	
+}

--- a/src/main/java/es/uji/crypto/xades/jxades/security/xml/XAdES/SignerRoleV2Details.java
+++ b/src/main/java/es/uji/crypto/xades/jxades/security/xml/XAdES/SignerRoleV2Details.java
@@ -1,0 +1,81 @@
+package es.uji.crypto.xades.jxades.security.xml.XAdES;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+
+/**
+ * 
+ * <p:SignerRoleV2>
+ *     <p:ClaimedRoles>
+ *         <p:ClaimedRole>
+ *             ANYTYPE
+ *         </p:ClaimedRole>
+ *     </p:ClaimedRoles>
+ *     <p:CertifiedRolesV2>
+ *         <p:CertifiedRole>
+ *             ANYTYPE
+ *         </p:CertifiedRole>
+ *     </p:CertifiedRolesV2>
+ *     <p:SignedAssertions>
+ *         ANYTYPE
+ *     <p:SignedAssertions>
+ * </p:SignerRoleV2>
+ */
+
+public class SignerRoleV2Details extends XAdESStructure
+{
+    public SignerRoleV2Details(Document document, SignedSignatureProperties ssp, SignerRoleV2 signerRoleV2,
+            String xadesPrefix, String xadesNamespace, String xmlSignaturePrefix)
+    {
+        super(document, ssp, "SignerRoleV2", xadesPrefix, xadesNamespace, xmlSignaturePrefix);
+
+        Element claimedRoles = createElement("ClaimedRoles");
+        Element certifiedRoles = createElement("CertifiedRolesV2");
+        Element signedAssertions = createElement("SignedAssertions");
+
+        for (String sr : signerRoleV2.getClaimedRoles())
+        {
+            Element claimedRole = createElement("ClaimedRole");
+            claimedRole.setTextContent(sr);
+            claimedRoles.appendChild(claimedRole);
+        }
+
+        // TODO: Implement support for certified role and attribute certificates management
+        for (String sr : signerRoleV2.getCertifiedRolesV2())
+        {
+            Element certifiedRole = createElement("CertifiedRole");
+            certifiedRole.setTextContent(sr);
+            certifiedRoles.appendChild(certifiedRole);
+        }
+        
+        // TODO: Implement support for signed assertions
+        for (String sr : signerRoleV2.getSignedAssertions())
+        {
+            Element signedAssertion = createElement("SignedAssertion");
+            signedAssertion.setTextContent(sr);
+            signedAssertions.appendChild(signedAssertion);
+        }
+
+        if (signerRoleV2.getClaimedRoles().size() > 0)
+        {
+            getNode().appendChild(claimedRoles);
+        }
+
+        if (signerRoleV2.getCertifiedRolesV2().size() > 0)
+        {
+            getNode().appendChild(certifiedRoles);
+        }
+        
+        if (signerRoleV2.getSignedAssertions().size() > 0)
+        {
+            getNode().appendChild(signedAssertions);
+        }
+    }
+
+    public SignerRoleV2Details(Node node, String xadesPrefix, String xadesNamespace,
+            String xmlSignaturePrefix)
+    {
+        super(node, xadesPrefix, xadesNamespace, xmlSignaturePrefix);
+    }
+}

--- a/src/main/java/es/uji/crypto/xades/jxades/security/xml/XAdES/SignerRoleV2Impl.java
+++ b/src/main/java/es/uji/crypto/xades/jxades/security/xml/XAdES/SignerRoleV2Impl.java
@@ -1,0 +1,57 @@
+package es.uji.crypto.xades.jxades.security.xml.XAdES;
+
+import java.util.ArrayList;
+
+public class SignerRoleV2Impl implements SignerRoleV2
+{
+	private ArrayList<String> claimedRoles;
+	private ArrayList<String> certifiedRolesV2;
+	private ArrayList<String> signedAssertions;
+
+	public SignerRoleV2Impl()
+	{
+		this.claimedRoles = new ArrayList<String>();
+		this.certifiedRolesV2 = new ArrayList<String>();
+		this.signedAssertions = new ArrayList<String>();
+	}
+
+	public ArrayList<String> getClaimedRoles()
+	{
+		return this.claimedRoles;
+	}
+
+	public void setClaimedRoles(ArrayList<String> claimedRole)
+	{
+		this.claimedRoles = claimedRole;
+	}
+
+	public void addClaimedRole(String role)
+	{
+		this.claimedRoles.add(role);
+	}
+	
+	public ArrayList<String> getCertifiedRolesV2()
+	{
+		return this.certifiedRolesV2;
+	}
+
+	public void setCertifiedRolesV2(ArrayList<String> certifiedRole)
+	{
+		this.certifiedRolesV2 = certifiedRole;
+	}
+
+	public void addCertifiedRoleV2(String role)
+	{
+		this.certifiedRolesV2.add(role);
+	}
+	
+	public ArrayList<String> getSignedAssertions()
+	{
+		return this.signedAssertions;
+	}
+
+	public void setSignedAssertions(ArrayList<String> signedAssertions)
+	{
+		this.signedAssertions = signedAssertions;
+	}
+}

--- a/src/main/java/es/uji/crypto/xades/jxades/security/xml/XAdES/SigningCertificate.java
+++ b/src/main/java/es/uji/crypto/xades/jxades/security/xml/XAdES/SigningCertificate.java
@@ -1,12 +1,9 @@
 package es.uji.crypto.xades.jxades.security.xml.XAdES;
 
 import java.math.BigInteger;
-import java.security.GeneralSecurityException;
 
-public interface SigningCertificate 
+public interface SigningCertificate extends SigningCertificateBase 
 {
-	public String getDigestMethodAlgorithm();
-	public String getDigestValue() throws GeneralSecurityException;
 	public String getIssuerName();
 	public BigInteger getX509SerialNumber();
 }

--- a/src/main/java/es/uji/crypto/xades/jxades/security/xml/XAdES/SigningCertificateBase.java
+++ b/src/main/java/es/uji/crypto/xades/jxades/security/xml/XAdES/SigningCertificateBase.java
@@ -1,0 +1,9 @@
+package es.uji.crypto.xades.jxades.security.xml.XAdES;
+
+import java.security.GeneralSecurityException;
+
+public interface SigningCertificateBase 
+{
+	public String getDigestMethodAlgorithm();
+	public String getDigestValue() throws GeneralSecurityException;
+}

--- a/src/main/java/es/uji/crypto/xades/jxades/security/xml/XAdES/SigningCertificateInfo.java
+++ b/src/main/java/es/uji/crypto/xades/jxades/security/xml/XAdES/SigningCertificateInfo.java
@@ -1,0 +1,8 @@
+package es.uji.crypto.xades.jxades.security.xml.XAdES;
+
+/**
+ * Information to add to a signing certificate element.
+ */
+public interface SigningCertificateInfo
+{
+}

--- a/src/main/java/es/uji/crypto/xades/jxades/security/xml/XAdES/SigningCertificateV2.java
+++ b/src/main/java/es/uji/crypto/xades/jxades/security/xml/XAdES/SigningCertificateV2.java
@@ -1,0 +1,7 @@
+package es.uji.crypto.xades.jxades.security.xml.XAdES;
+
+public interface SigningCertificateV2 extends SigningCertificateBase 
+{
+	void setIssuerSerialV2(String issuerSerial);
+	String getIssuerSerialV2();
+}

--- a/src/main/java/es/uji/crypto/xades/jxades/security/xml/XAdES/SigningCertificateV2Details.java
+++ b/src/main/java/es/uji/crypto/xades/jxades/security/xml/XAdES/SigningCertificateV2Details.java
@@ -1,0 +1,66 @@
+package es.uji.crypto.xades.jxades.security.xml.XAdES;
+
+import java.security.GeneralSecurityException;
+
+import javax.xml.crypto.dsig.XMLSignature;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+
+/**
+ * Sample usage of SigningCertificateV2:
+ *
+ * <xades:SigningCertificateV2>
+ *     <xades:Cert>
+ *         <xades:CertDigest>
+ *             <ds:DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1" />
+ *             <ds:DigestValue>rFQEEAdlZJieHIdInK8bYoB6aMs=</ds:DigestValue>
+ *         </xades:CertDigest>
+ *         <xades:IssuerSerialV2>MIGeMIGQpIGNMIGKMQswCQYDVQQGEwJMSzEQMA4GA1UECBMHV2VzdGVybjEQMA4GA1UEBxMHQ29sb21ibzEWMBQGA1UEChMNU29mdHdhcmUgVmlldzERMA8GA1UECxMIVHJhaW5pbmcxLDAqBgNVBAMTI1NvZnR3YXJlIFZpZXcgQ2VydGlmaWNhdGUgQXV0aG9yaXR5AgkA9qs6c/ASQqU=</xades:IssuerSerialV2>
+ *     </xades:Cert>
+ * </xades:SigningCertificate>
+ *
+ */
+
+public class SigningCertificateV2Details extends XAdESStructure
+{
+    public SigningCertificateV2Details(final Document document, final SignedSignatureProperties ssp,
+            final SigningCertificateV2 signingCertificate, final String xadesPrefix, final String xadesNamespace,
+            final String xmlSignaturePrefix) throws GeneralSecurityException
+    {
+        super(document, ssp, "SigningCertificateV2", xadesPrefix, xadesNamespace, xmlSignaturePrefix);
+
+        // TODO: Unimplemented URI parameter
+        final Element cert = createElement("Cert");
+
+        final Element certDigest = createElement("CertDigest");
+
+        final Element digestMethod = createElementNS(XMLSignature.XMLNS, xmlSignaturePrefix,
+                "DigestMethod");
+        digestMethod.setPrefix(xmlSignaturePrefix);
+        digestMethod.setAttributeNS(xmlSignaturePrefix, "Algorithm", signingCertificate.getDigestMethodAlgorithm());
+
+        final Element digestValue = createElementNS(XMLSignature.XMLNS, xmlSignaturePrefix, "DigestValue");
+        digestValue.setPrefix(xmlSignaturePrefix);
+        digestValue.setTextContent(signingCertificate.getDigestValue());
+
+        certDigest.appendChild(digestMethod);
+        certDigest.appendChild(digestValue);
+
+
+        final Element issuerSerial = createElement("IssuerSerialV2");
+        issuerSerial.setTextContent(signingCertificate.getIssuerSerialV2());
+
+        cert.appendChild(certDigest);
+        cert.appendChild(issuerSerial);
+
+        getNode().appendChild(cert);
+    }
+
+    public SigningCertificateV2Details(final Node node, final String xadesPrefix, final String xadesNamespace,
+            final String xmlSignaturePrefix)
+    {
+        super(node, xadesPrefix, xadesNamespace, xmlSignaturePrefix);
+    }
+}

--- a/src/main/java/es/uji/crypto/xades/jxades/security/xml/XAdES/SigningCertificateV2Impl.java
+++ b/src/main/java/es/uji/crypto/xades/jxades/security/xml/XAdES/SigningCertificateV2Impl.java
@@ -1,0 +1,60 @@
+package es.uji.crypto.xades.jxades.security.xml.XAdES;
+
+import java.security.GeneralSecurityException;
+import java.security.MessageDigest;
+import java.security.cert.X509Certificate;
+
+import javax.xml.crypto.dsig.DigestMethod;
+
+import es.uji.crypto.xades.jxades.util.Base64;
+
+public class SigningCertificateV2Impl implements SigningCertificateV2
+{
+	private X509Certificate certificate;
+	private String digestMethod;
+	private String issuerSerial = null;
+	
+	public SigningCertificateV2Impl(final X509Certificate certificate, final String digestMethod) 
+	{
+		this.certificate = certificate;
+		this.digestMethod = digestMethod;
+	}
+
+	public String getDigestMethodAlgorithm() 
+	{
+		return this.digestMethod;
+	}
+
+	public String getDigestValue() throws GeneralSecurityException
+	{
+		String result;
+		
+		try
+		{
+		    String algorithm = "SHA-256"; //$NON-NLS-1$
+
+		    if (DigestMethod.SHA512.equals(this.digestMethod))
+		    {
+                algorithm = "SHA-512"; //$NON-NLS-1$
+		    }
+		    
+			MessageDigest md = MessageDigest.getInstance(algorithm);	
+			md.update(this.certificate.getEncoded());
+			result = Base64.encodeBytes(md.digest());
+		}
+		catch (Exception e)
+		{
+			throw new GeneralSecurityException(e);
+		}
+		
+		return result;
+	}
+
+	public void setIssuerSerialV2(final String issuerSerial) {
+		this.issuerSerial = issuerSerial;
+	}
+	
+	public String getIssuerSerialV2() {
+		return this.issuerSerial;
+	}
+}

--- a/src/main/java/es/uji/crypto/xades/jxades/security/xml/XAdES/SigningCertificateV2Info.java
+++ b/src/main/java/es/uji/crypto/xades/jxades/security/xml/XAdES/SigningCertificateV2Info.java
@@ -1,0 +1,17 @@
+package es.uji.crypto.xades.jxades.security.xml.XAdES;
+
+/**
+ * Extra information required by a SigningCertitifcateV2 element.
+ */
+public class SigningCertificateV2Info implements SigningCertificateInfo {
+
+	private String issuerSerialV2; 
+	
+	public SigningCertificateV2Info(String issuerSerialEncoded) {
+		this.issuerSerialV2 = issuerSerialEncoded;
+	}
+	
+	public String getIssuerSerialV2() {
+		return this.issuerSerialV2;
+	}
+}

--- a/src/main/java/es/uji/crypto/xades/jxades/security/xml/XAdES/XAdES.java
+++ b/src/main/java/es/uji/crypto/xades/jxades/security/xml/XAdES/XAdES.java
@@ -12,21 +12,12 @@ import org.w3c.dom.Document;
 import org.w3c.dom.NodeList;
 
 /**
- * ETSI TS 101 903 V1.3.2 (2006-03)
- *
- * Xml Advanced Electronic Signature (XAdES)
- *
- * 4.4 Electronic signature forms
- * The current clause specifies four forms of XML advanced
- * electronic signatures, namely the Basic Electronic
- * Signature (XAdES-BES), the Explicit Policy based
- * Electronic Signature (XAdES-EPES), and the Electronic
- * Signature with Validation Data (XAdES-T and XAdES-C).
- * Conformance to the present document mandates the
- * signer to create one of these formats.
- * The informative annex B defines extended forms of XAdES.
- * Conformance to the present document does not mandate
- * the signer to create any of the forms defined in annex B.
+ * Xml Advanced Electronic Signature (XAdES) profiles are
+ * defined in:
+ * <ul>
+ *   <li>ETSI TS 101 903 V1.3.2 (2006-03)</li>
+ *   <li>ETSI EN 319 132-1 V1.1.1 (2016-04)</li>
+ * </ul>
  *
  * Similar/related projects/standards:
  * - RFC3126 (http://www.ietf.org/rfc/rfc3126.txt,
@@ -49,10 +40,10 @@ public enum XAdES
      * of these formats. The informative annex B defines extended forms of XAdES. Conformance to the
      * present document does not mandate the signer to create any of the forms defined in annex B.
      **/
-    BES("XAdES-BES", "4.4.1", "Basic Electronic Signature"), EPES("XAdES-EPES", "4.4.2",
-            "Explicit Policy Electronic Signatures"), T("XAdES-T", "4.4.3.1",
-            "Electronic Signature with Time"), C("XAdES-C", "4.4.3.2",
-            "Electronic Signature with Complete Validation Data References"),
+    BES("XAdES-BES", "4.4.1", "Basic Electronic Signature"),
+    EPES("XAdES-EPES", "4.4.2", "Explicit Policy Electronic Signatures"),
+    T("XAdES-T", "4.4.3.1", "Electronic Signature with Time"),
+    C("XAdES-C", "4.4.3.2", "Electronic Signature with Complete Validation Data References"),
 
     /**
      * 4.5 Validation process The Validation Process validates an electronic signature, the output
@@ -94,9 +85,29 @@ public enum XAdES
      * present document. The clauses below give an overview of the various forms of extended
      * signature formats in the present document.
      **/
-    X("XAdES-X", "B.1", "Extended Signatures with Time Forms"), X_L("XAdES-X-L", "B.2",
-            "Extended Long Electronic Signatures with Time"), A("XAdES-A", "B.3",
-            "Archival Electronic Signatures");
+    X("XAdES-X", "B.1", "Extended Signatures with Time Forms"),
+    X_L("XAdES-X-L", "B.2", "Extended Long Electronic Signatures with Time"),
+    A("XAdES-A", "B.3", "Archival Electronic Signatures"),
+    
+    /**
+     * ETSI EN 319 132-1 V1.1.1 6.3<br>
+     * <br>
+     * 6.1 Signature levels<br>
+     * Clause 6 defines four levels of XAdES baseline signatures, intended to facilitate interoperability and to encompass the
+     * life cycle of XAdES signature, namely:<br>
+     * <ol>
+     * <li>B-B level provides requirements for the incorporation of signed and some unsigned qualifying properties when
+     * the signature is generated.</li>
+     * <li>B-T level provides requirements for the generation and inclusion, for an existing signature, of a trusted token
+     * proving that the signature itself actually existed at a certain date and time.</li>
+     * <li>B-LT level provides requirements for the incorporation of all the material required for validating the signature
+     * in the signature document. This level aims to tackle the long term availability of the validation material.</li>
+     * <li>B-LTA level provides requirements for the incorporation of electronic time-stamps that allow validation of the
+     * signature long time after its generation. This level aims to tackle the long term availability and integrity of the
+     * validation material.</li>
+     * </ol>
+     */
+    B_LEVEL("B-B-LEVEL", "ETSI EN 319 132-1 V1.1.1 6.3", "XAdES BASELINE B-LEVEL");
 
     private XAdES(String nickname, String contentsId, String title)
     {
@@ -126,43 +137,37 @@ public enum XAdES
 
     public enum Element implements XadesElement
     {
-        OBJECT(null, "Object"), QUALIFYING_PROPERTIES(OBJECT, "QualifyingProperties"), SIGNED_PROPERTIES(
-                QUALIFYING_PROPERTIES, "SignedProperties"), SIGNED_SIGNATURE_PROPERTIES(
-                SIGNED_PROPERTIES, "SignedSignatureProperties"), SIGNING_TIME(XAdES.BES,
-                SIGNED_SIGNATURE_PROPERTIES, "SigningTime", OccursRequirement.ZERO_OR_ONE), SIGNING_CERTIFICATE(
-                XAdES.BES, SIGNED_SIGNATURE_PROPERTIES, "SigningCertificate",
-                OccursRequirement.ZERO_OR_ONE), SIGNATURE_POLICY_IDENTIFIER(
-                XAdES.EPES, SIGNED_SIGNATURE_PROPERTIES, "SignaturePolicyIdentifier",
-                OccursRequirement.EXACTLY_ONE), SIGNATURE_PRODUCTION_PLACE(XAdES.BES,
-                SIGNED_SIGNATURE_PROPERTIES, "SignatureProductionPlace",
-                OccursRequirement.ZERO_OR_ONE), SIGNER_ROLE(XAdES.BES, SIGNED_SIGNATURE_PROPERTIES,
-                "SignerRole", OccursRequirement.ZERO_OR_ONE), CLAIMED_ROLES(XAdES.BES, SIGNER_ROLE,
-                "ClaimedRoles", OccursRequirement.ZERO_OR_MORE), CERTIFIED_ROLES(XAdES.BES,
-                SIGNER_ROLE, "CertifiedRoles", OccursRequirement.ZERO_OR_MORE), SIGNER(XAdES.BES, SIGNED_SIGNATURE_PROPERTIES,
-                "Signer", OccursRequirement.ZERO_OR_ONE), SIGNER_DETAILS(XAdES.BES,
-                SIGNED_SIGNATURE_PROPERTIES, "SignerDetails", OccursRequirement.ZERO_OR_ONE), SIGNED_DATA_OBJECT_PROPERTIES(
-                SIGNED_PROPERTIES, "SignedDataObjectProperties"), DATA_OBJECT_FORMATS(XAdES.BES,
-                SIGNED_DATA_OBJECT_PROPERTIES, "DataObjectFormat", OccursRequirement.ZERO_OR_MORE), COMMITMENT_TYPE_INDICATIONS(
-                XAdES.BES, SIGNED_DATA_OBJECT_PROPERTIES, "CommitmentTypeIndication",
-                OccursRequirement.ZERO_OR_MORE), ALL_DATA_OBJECTS_TIMESTAMPS(XAdES.BES,
-                SIGNED_DATA_OBJECT_PROPERTIES, "AllDataObjectsTimeStamp",
-                OccursRequirement.ZERO_OR_MORE), INDIVIDUAL_DATA_OBJECTS_TIMESTAMPS(XAdES.BES,
-                SIGNED_DATA_OBJECT_PROPERTIES, "IndividualDataObjectsTimeStamp",
-                OccursRequirement.ZERO_OR_MORE), UNSIGNED_PROPERTIES(QUALIFYING_PROPERTIES,
-                "UnsignedProperties"), UNSIGNED_SIGNATURE_PROPERTIES(UNSIGNED_PROPERTIES,
-                "UnsignedSignatureProperties"), COUNTER_SIGNATURES(XAdES.BES,
-                UNSIGNED_SIGNATURE_PROPERTIES, "CounterSignature", OccursRequirement.ZERO_OR_MORE), SIGNATURE_TIME_STAMP(
-                XAdES.T, UNSIGNED_SIGNATURE_PROPERTIES, "SignatureTimeStamp",
-                OccursRequirement.ONE_OR_MORE), COMPLETE_CERTIFICATE_REFS(XAdES.C,
-                UNSIGNED_SIGNATURE_PROPERTIES, "CompleteCertificateRefs",
-                OccursRequirement.EXACTLY_ONE), COMPLETE_REVOCATION_REFS(XAdES.C,
-                UNSIGNED_SIGNATURE_PROPERTIES, "CompleteRevocationRefs",
-                OccursRequirement.EXACTLY_ONE), ATTRIBUTE_CERTIFICATE_REFS(XAdES.C,
-                UNSIGNED_SIGNATURE_PROPERTIES, "AttributeCertificateRefs",
-                OccursRequirement.ZERO_OR_ONE), ATTRIBUTE_REVOCATION_REFS(XAdES.C,
-                UNSIGNED_SIGNATURE_PROPERTIES, "CompleteCertificateRefs",
-                OccursRequirement.ZERO_OR_ONE), QUALIFYING_PROPERTIES_REFERENCE(OBJECT,
-                "QualifyingPropertiesReference");
+        OBJECT(null, "Object"),
+        QUALIFYING_PROPERTIES(OBJECT, "QualifyingProperties"),
+        SIGNED_PROPERTIES(QUALIFYING_PROPERTIES, "SignedProperties"),
+        SIGNED_SIGNATURE_PROPERTIES(SIGNED_PROPERTIES, "SignedSignatureProperties"),
+        SIGNING_TIME(XAdES.BES, SIGNED_SIGNATURE_PROPERTIES, "SigningTime", OccursRequirement.ZERO_OR_ONE),
+        SIGNING_CERTIFICATE(XAdES.BES, SIGNED_SIGNATURE_PROPERTIES, "SigningCertificate", OccursRequirement.ZERO_OR_ONE),
+        SIGNATURE_POLICY_IDENTIFIER(XAdES.EPES, SIGNED_SIGNATURE_PROPERTIES, "SignaturePolicyIdentifier", OccursRequirement.EXACTLY_ONE),
+        SIGNATURE_PRODUCTION_PLACE(XAdES.BES, SIGNED_SIGNATURE_PROPERTIES, "SignatureProductionPlace", OccursRequirement.ZERO_OR_ONE),
+        SIGNER_ROLE(XAdES.BES, SIGNED_SIGNATURE_PROPERTIES, "SignerRole", OccursRequirement.ZERO_OR_ONE),
+        CLAIMED_ROLES(XAdES.BES, SIGNER_ROLE, "ClaimedRoles", OccursRequirement.ZERO_OR_MORE),
+        CERTIFIED_ROLES(XAdES.BES, SIGNER_ROLE, "CertifiedRoles", OccursRequirement.ZERO_OR_MORE),
+        SIGNER(XAdES.BES, SIGNED_SIGNATURE_PROPERTIES, "Signer", OccursRequirement.ZERO_OR_ONE),
+        SIGNER_DETAILS(XAdES.BES, SIGNED_SIGNATURE_PROPERTIES, "SignerDetails", OccursRequirement.ZERO_OR_ONE),
+        SIGNED_DATA_OBJECT_PROPERTIES(SIGNED_PROPERTIES, "SignedDataObjectProperties"),
+        DATA_OBJECT_FORMATS(XAdES.BES, SIGNED_DATA_OBJECT_PROPERTIES, "DataObjectFormat", OccursRequirement.ZERO_OR_MORE),
+        COMMITMENT_TYPE_INDICATIONS(XAdES.BES, SIGNED_DATA_OBJECT_PROPERTIES, "CommitmentTypeIndication", OccursRequirement.ZERO_OR_MORE),
+        ALL_DATA_OBJECTS_TIMESTAMPS(XAdES.BES, SIGNED_DATA_OBJECT_PROPERTIES, "AllDataObjectsTimeStamp", OccursRequirement.ZERO_OR_MORE),
+        INDIVIDUAL_DATA_OBJECTS_TIMESTAMPS(XAdES.BES, SIGNED_DATA_OBJECT_PROPERTIES, "IndividualDataObjectsTimeStamp", OccursRequirement.ZERO_OR_MORE),
+        UNSIGNED_PROPERTIES(QUALIFYING_PROPERTIES, "UnsignedProperties"),
+        UNSIGNED_SIGNATURE_PROPERTIES(UNSIGNED_PROPERTIES, "UnsignedSignatureProperties"),
+        COUNTER_SIGNATURES(XAdES.BES, UNSIGNED_SIGNATURE_PROPERTIES, "CounterSignature", OccursRequirement.ZERO_OR_MORE),
+        SIGNATURE_TIME_STAMP( XAdES.T, UNSIGNED_SIGNATURE_PROPERTIES, "SignatureTimeStamp", OccursRequirement.ONE_OR_MORE),
+        COMPLETE_CERTIFICATE_REFS(XAdES.C, UNSIGNED_SIGNATURE_PROPERTIES, "CompleteCertificateRefs", OccursRequirement.EXACTLY_ONE),
+        COMPLETE_REVOCATION_REFS(XAdES.C, UNSIGNED_SIGNATURE_PROPERTIES, "CompleteRevocationRefs", OccursRequirement.EXACTLY_ONE),
+        ATTRIBUTE_CERTIFICATE_REFS(XAdES.C, UNSIGNED_SIGNATURE_PROPERTIES, "AttributeCertificateRefs", OccursRequirement.ZERO_OR_ONE),
+        ATTRIBUTE_REVOCATION_REFS(XAdES.C, UNSIGNED_SIGNATURE_PROPERTIES, "CompleteCertificateRefs", OccursRequirement.ZERO_OR_ONE),
+        QUALIFYING_PROPERTIES_REFERENCE(OBJECT, "QualifyingPropertiesReference"),
+        
+        /** XAdES Baseline attributes */
+        SIGNING_CERTIFICATE_V2(XAdES.B_LEVEL, SIGNED_SIGNATURE_PROPERTIES, "SigningCertificateV2", OccursRequirement.EXACTLY_ONE);
+        
 
         private Element(XadesElement parent, String elementName)
         {
@@ -250,14 +255,16 @@ public enum XAdES
             Element.values(), X_L);
     public static final XadesElementsEnumeration XAdES_A_ELEMENTS = new XadesElementsEnumeration(
             Element.values(), A);
+    public static final XadesElementsEnumeration XAdES_B_LEVEL_ELEMENTS = new XadesElementsEnumeration(
+            Element.values(), XAdES.B_LEVEL);
 
-    public static XAdES_BES newInstance(XAdES xades, org.w3c.dom.Element baseElement)
+    public static XAdESBase newInstance(XAdES xades, org.w3c.dom.Element baseElement)
     {
         return newInstance(xades, XMLAdvancedSignature.XADES_v132, "xades", "dsign",
                 DigestMethod.SHA1, baseElement.getOwnerDocument(), baseElement);
     }
 
-    public static XAdES_BES newInstance(XAdES xades)
+    public static XAdESBase newInstance(XAdES xades)
     {
         try
         {
@@ -276,7 +283,7 @@ public enum XAdES
         }
     }
 
-    public static XAdES_BES newInstance(XAdES xades, String xadesNamespace, String xadesPrefix,
+    public static XAdESBase newInstance(XAdES xades, String xadesNamespace, String xadesPrefix,
             String xmlSignaturePrefix, String digestMethod, Document document,
             org.w3c.dom.Element baseElement)
     {
@@ -315,6 +322,11 @@ public enum XAdES
         else if (A.equals(xades))
         {
             return new ArchivalXAdESImpl(document, baseElement, false, xadesPrefix, xadesNamespace,
+                    xmlSignaturePrefix, digestMethod);
+        }
+        else if (B_LEVEL.equals(xades))
+        {
+            return new BLevelXAdESImpl(document, baseElement, false, xadesPrefix, xadesNamespace,
                     xmlSignaturePrefix, digestMethod);
         }
 

--- a/src/main/java/es/uji/crypto/xades/jxades/security/xml/XAdES/XAdES.java
+++ b/src/main/java/es/uji/crypto/xades/jxades/security/xml/XAdES/XAdES.java
@@ -166,9 +166,11 @@ public enum XAdES
         QUALIFYING_PROPERTIES_REFERENCE(OBJECT, "QualifyingPropertiesReference"),
         
         /** XAdES Baseline attributes */
-        SIGNING_CERTIFICATE_V2(XAdES.B_LEVEL, SIGNED_SIGNATURE_PROPERTIES, "SigningCertificateV2", OccursRequirement.EXACTLY_ONE);
-        
-
+        SIGNING_CERTIFICATE_V2(XAdES.B_LEVEL, SIGNED_SIGNATURE_PROPERTIES, "SigningCertificateV2", OccursRequirement.EXACTLY_ONE),
+    	SIGNER_ROLE_V2(XAdES.B_LEVEL, SIGNED_SIGNATURE_PROPERTIES, "SignerRoleV2", OccursRequirement.ZERO_OR_ONE),
+    	CERTIFIED_ROLES_V2(XAdES.B_LEVEL, SIGNER_ROLE_V2, "CertifiedRolesV2", OccursRequirement.ZERO_OR_MORE),
+    	SIGNED_ASSERTIONS(XAdES.B_LEVEL, SIGNER_ROLE_V2, "SignedAssertions", OccursRequirement.ZERO_OR_MORE);
+    	
         private Element(XadesElement parent, String elementName)
         {
             this(null, parent, elementName, OccursRequirement.EXACTLY_ONE);

--- a/src/main/java/es/uji/crypto/xades/jxades/security/xml/XAdES/XAdES.java
+++ b/src/main/java/es/uji/crypto/xades/jxades/security/xml/XAdES/XAdES.java
@@ -167,7 +167,8 @@ public enum XAdES
         
         /** XAdES Baseline attributes */
         SIGNING_CERTIFICATE_V2(XAdES.B_LEVEL, SIGNED_SIGNATURE_PROPERTIES, "SigningCertificateV2", OccursRequirement.EXACTLY_ONE),
-    	SIGNER_ROLE_V2(XAdES.B_LEVEL, SIGNED_SIGNATURE_PROPERTIES, "SignerRoleV2", OccursRequirement.ZERO_OR_ONE),
+        SIGNATURE_PRODUCTION_PLACE_V2(XAdES.B_LEVEL, SIGNED_SIGNATURE_PROPERTIES, "SignatureProductionPlaceV2", OccursRequirement.ZERO_OR_ONE),
+        SIGNER_ROLE_V2(XAdES.B_LEVEL, SIGNED_SIGNATURE_PROPERTIES, "SignerRoleV2", OccursRequirement.ZERO_OR_ONE),
     	CERTIFIED_ROLES_V2(XAdES.B_LEVEL, SIGNER_ROLE_V2, "CertifiedRolesV2", OccursRequirement.ZERO_OR_MORE),
     	SIGNED_ASSERTIONS(XAdES.B_LEVEL, SIGNER_ROLE_V2, "SignedAssertions", OccursRequirement.ZERO_OR_MORE);
     	

--- a/src/main/java/es/uji/crypto/xades/jxades/security/xml/XAdES/XAdESBase.java
+++ b/src/main/java/es/uji/crypto/xades/jxades/security/xml/XAdES/XAdESBase.java
@@ -1,0 +1,40 @@
+package es.uji.crypto.xades.jxades.security.xml.XAdES;
+
+import java.security.cert.X509Certificate;
+import java.util.Date;
+import java.util.List;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+public interface XAdESBase {
+
+    public Element getBaseElement();
+    public Document getBaseDocument();
+
+    public Date getSigningTime();
+    public void setSigningTime(Date signingTime);
+
+    public Signer getSigner();
+    public void setSigner(Signer signer);
+
+    public List<DataObjectFormat> getDataObjectFormats();
+    public void setDataObjectFormats(List<DataObjectFormat> dataObjectFormats);
+
+    public List<CommitmentTypeIndication> getCommitmentTypeIndications();
+    public void setCommitmentTypeIndications(List<CommitmentTypeIndication> commitmentTypeIndications);
+
+    public List<AllDataObjectsTimeStamp> getAllDataObjectsTimeStamps();
+    public void setAllDataObjectsTimeStamps(List<AllDataObjectsTimeStamp> allDataObjectsTimeStamps);
+
+    public List<XAdESTimeStamp> getIndividualDataObjectsTimeStamps();
+    public void setIndividualDataObjectsTimeStamps(List<IndividualDataObjectsTimeStamp> individualDataObjectsTimeStamps);
+
+    public List<CounterSignature> getCounterSignatures();
+    public void setCounterSignatures(List<CounterSignature> counterSignatures);   
+    
+    public String getXadesPrefix();
+    public String getXadesNamespace();
+    public String getXmlSignaturePrefix();
+    public String getDigestMethod();
+}

--- a/src/main/java/es/uji/crypto/xades/jxades/security/xml/XAdES/XAdES_BES.java
+++ b/src/main/java/es/uji/crypto/xades/jxades/security/xml/XAdES/XAdES_BES.java
@@ -127,43 +127,6 @@ import org.w3c.dom.Element;
  *
  * @author miro
  */
-public interface XAdES_BES
+public interface XAdES_BES extends XAdESBase, XadesWithBasicAttributes
 {
-    public Element getBaseElement();
-    public Document getBaseDocument();
-
-    public Date getSigningTime();
-    public void setSigningTime(Date signingTime);
-
-    public X509Certificate getSigningCertificate();
-    public void setSigningCertificate(X509Certificate certificate);
-
-    public SignatureProductionPlace getSignatureProductionPlace();
-    public void setSignatureProductionPlace(SignatureProductionPlace productionPlace);
-
-    public SignerRole getSignerRole();
-    public void setSignerRole(SignerRole signerRole);
-
-    public Signer getSigner();
-    public void setSigner(Signer signer);
-
-    public List<DataObjectFormat> getDataObjectFormats();
-    public void setDataObjectFormats(List<DataObjectFormat> dataObjectFormats);
-
-    public List<CommitmentTypeIndication> getCommitmentTypeIndications();
-    public void setCommitmentTypeIndications(List<CommitmentTypeIndication> commitmentTypeIndications);
-
-    public List<AllDataObjectsTimeStamp> getAllDataObjectsTimeStamps();
-    public void setAllDataObjectsTimeStamps(List<AllDataObjectsTimeStamp> allDataObjectsTimeStamps);
-
-    public List<XAdESTimeStamp> getIndividualDataObjectsTimeStamps();
-    public void setIndividualDataObjectsTimeStamps(List<IndividualDataObjectsTimeStamp> individualDataObjectsTimeStamps);
-
-    public List<CounterSignature> getCounterSignatures();
-    public void setCounterSignatures(List<CounterSignature> counterSignatures);   
-    
-    public String getXadesPrefix();
-    public String getXadesNamespace();
-    public String getXmlSignaturePrefix();
-    public String getDigestMethod();
 }

--- a/src/main/java/es/uji/crypto/xades/jxades/security/xml/XAdES/XAdES_B_Level.java
+++ b/src/main/java/es/uji/crypto/xades/jxades/security/xml/XAdES/XAdES_B_Level.java
@@ -1,0 +1,99 @@
+package es.uji.crypto.xades.jxades.security.xml.XAdES;
+
+import java.security.cert.X509Certificate;
+import java.util.Date;
+import java.util.List;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+/**
+ * ETSI EN 319 132-1 V1.1.1 Electronic Signatures and Infrastructures (ESI);
+ *
+ * 4.2 & Annex C) ETSI defines two XML Schema files for the present specification:
+ *  - http://uri.etsi.org/01903/v1.3.2/XAdES01903v132-201601.xsd contains the
+ *  definitions of qualifying properties defined within the namespace whose URI value is http://uri.etsi.org/01903/v1.3.2#.
+ *  - http://uri.etsi.org/01903/v1.4.1/XAdES01903v141-201601.xsd contains the
+ * definitions of qualifying properties defined within the namespace whose URI value is http://uri.etsi.org/01903/v1.4.1#.
+ *
+ * 6.3 Requirements on XAdES signature's elements, qualifying properties and services
+ *
+ * Requirements for XAdES-B-B:
+ *  - ds:KeyInfo/X509Data                      shall be present
+ *  - ds:SignedInfo/ds:CanonicalizationMethod  shall be present
+ *  - ds:Reference shall be present            shall be present
+ *      - ds:Reference/ds:Transforms           may be present
+ *  - SigningTime                              shall be present
+ *  - SigningCertificateV2                     shall be present
+ *  - SigningCertificate shall                 not be present
+ *  - DataObjectFormat                         conditioned presence
+ *      - DataObjectFormat/Description         may be present
+ *      - DataObjectFormat/ObjectIdentifier    may be present
+ *      - DataObjectFormat/MimeType            shall be present
+ *      - DataObjectFormat/Encoding            may be present
+ *      - ObjectReference attribute            shall be present
+ *  - SignerRole                               shall not be present
+ *  - SignerRoleV2                             may be present
+ *  - CommitmentTypeIndication                 may be present
+ *  - SignatureProductionPlaceV2               may be present
+ *  - SignatureProductionPlace                 shall not be present
+ *  - CounterSignature                         may be present
+ *  - AllDataObjectsTimeStamp                  may be present
+ *  - IndividualDataObjectsTimeStamp           may be present
+ *  - SignaturePolicyIdentifier                may be present
+ *  - SignaturePolicyStore                     conditioned presence
+ *  - CompleteCertificateRefs                  shall not be present
+ *  - AttributeCertificateRefs                 shall not be present
+ *  - SigAndRefsTimeStamp                      shall not be present
+ *  - RefsOnlyTimeStamp                        shall not be present
+ *  - ArchiveTimeStamp                         shall not be present
+ **/
+
+/*
+https://uri.etsi.org/01903/v1.3.2/XAdES01903v132-201601.xsd
+-----------------------------------------------------------
+
+<?xml version="1.0"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+		xmlns="http://uri.etsi.org/01903/v1.3.2#"
+		xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+		targetNamespace="http://uri.etsi.org/01903/v1.3.2#"
+		elementFormDefault="qualified">
+	<xsd:import namespace="http://www.w3.org/2000/09/xmldsig#"
+			schemaLocation="http://www.w3.org/TR/2008/REC-xmldsig-core-20080610/xmldsig-core-schema.xsd"/>
+
+        <ds:Signature ID?>
+            ...
+            <ds:Object>
+                <QualifyingProperties>
+                    <SignedProperties>
+                        <SignedSignatureProperties>
+                            (SigningTime)?
+                            (SigningCertificateV2)?
+                            (SignatureProductionPlaceV2)?
+                            (SignerRoleV2)?
+                        </SignedSignatureProperties>
+                        <SignedDataObjectProperties>
+                            (DataObjectFormat)*
+                            (CommitmentTypeIndication)*
+                            (AllDataObjectsTimeStamp)*
+                            (IndividualDataObjectsTimeStamp)*
+                        </SignedDataObjectProperties>
+                    </SignedProperties>
+                    <UnsignedProperties>
+                        <UnsignedSignatureProperties>
+                            (CounterSignature)*
+                        </UnsignedSignatureProperties>
+                    </UnsignedProperties>
+                </QualifyingProperties>
+            </ds:Object>
+        </ds:Signature>-
+    */
+
+/**
+ *
+ * @author miro
+ */
+public interface XAdES_B_Level extends XAdESBase, XadesWithBaselineAttributes, XadesWithExplicitPolicy
+{
+}

--- a/src/main/java/es/uji/crypto/xades/jxades/security/xml/XAdES/XAdES_EPES.java
+++ b/src/main/java/es/uji/crypto/xades/jxades/security/xml/XAdES/XAdES_EPES.java
@@ -35,8 +35,7 @@ form) is illustrated below.
  * @author miro
  */
 public interface XAdES_EPES
-    extends XAdES_BES
+    extends XAdES_BES, XadesWithExplicitPolicy
 {
-    public SignaturePolicyIdentifier getSignaturePolicyIdentifier();
-    public void setSignaturePolicyIdentifier(SignaturePolicyIdentifier signaturePolicyIdentifier);    
+
 }

--- a/src/main/java/es/uji/crypto/xades/jxades/security/xml/XAdES/XadesWithBaselineAttributes.java
+++ b/src/main/java/es/uji/crypto/xades/jxades/security/xml/XAdES/XadesWithBaselineAttributes.java
@@ -20,6 +20,11 @@ public interface XadesWithBaselineAttributes {
     SignatureProductionPlace getSignatureProductionPlace();
     void setSignatureProductionPlace(SignatureProductionPlace productionPlace);
 
-    SignerRole getSignerRole();
-    void setSignerRole(SignerRole signerRole);
+    SignerRoleV2 getSignerRoleV2();
+    
+    /**
+     * Set the signer roles.
+     * @param signerRole Signer's Roles.
+     */
+    void setSignerRoleV2(SignerRoleV2 signerRole);
 }

--- a/src/main/java/es/uji/crypto/xades/jxades/security/xml/XAdES/XadesWithBaselineAttributes.java
+++ b/src/main/java/es/uji/crypto/xades/jxades/security/xml/XAdES/XadesWithBaselineAttributes.java
@@ -1,11 +1,6 @@
 package es.uji.crypto.xades.jxades.security.xml.XAdES;
 
 import java.security.cert.X509Certificate;
-import java.util.Date;
-import java.util.List;
-
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
 
 public interface XadesWithBaselineAttributes {
 	
@@ -17,8 +12,13 @@ public interface XadesWithBaselineAttributes {
      */
     void setSigningCertificateV2(X509Certificate signingCertificate, SigningCertificateV2Info additionalInfo);
 
-    SignatureProductionPlace getSignatureProductionPlace();
-    void setSignatureProductionPlace(SignatureProductionPlace productionPlace);
+    SignatureProductionPlace getSignatureProductionPlaceV2();
+    
+    /**
+     * Set the production place.
+     * @param productionPlace Production place information.
+     */
+    void setSignatureProductionPlaceV2(SignatureProductionPlaceV2 productionPlace);
 
     SignerRoleV2 getSignerRoleV2();
     

--- a/src/main/java/es/uji/crypto/xades/jxades/security/xml/XAdES/XadesWithBaselineAttributes.java
+++ b/src/main/java/es/uji/crypto/xades/jxades/security/xml/XAdES/XadesWithBaselineAttributes.java
@@ -1,0 +1,25 @@
+package es.uji.crypto.xades.jxades.security.xml.XAdES;
+
+import java.security.cert.X509Certificate;
+import java.util.Date;
+import java.util.List;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+public interface XadesWithBaselineAttributes {
+	
+	SigningCertificateV2 getSigningCertificateV2();
+
+    /**
+     * Set the signing certificate.
+     * @param signingCertificate Signing certificate information.
+     */
+    void setSigningCertificateV2(X509Certificate signingCertificate, SigningCertificateV2Info additionalInfo);
+
+    SignatureProductionPlace getSignatureProductionPlace();
+    void setSignatureProductionPlace(SignatureProductionPlace productionPlace);
+
+    SignerRole getSignerRole();
+    void setSignerRole(SignerRole signerRole);
+}

--- a/src/main/java/es/uji/crypto/xades/jxades/security/xml/XAdES/XadesWithBasicAttributes.java
+++ b/src/main/java/es/uji/crypto/xades/jxades/security/xml/XAdES/XadesWithBasicAttributes.java
@@ -1,0 +1,15 @@
+package es.uji.crypto.xades.jxades.security.xml.XAdES;
+
+import java.security.cert.X509Certificate;
+
+public interface XadesWithBasicAttributes {
+	
+    public SigningCertificate getSigningCertificate();
+    public void setSigningCertificate(X509Certificate certificate);
+    
+    public SignatureProductionPlace getSignatureProductionPlace();
+    public void setSignatureProductionPlace(SignatureProductionPlace productionPlace);
+
+    public SignerRole getSignerRole();
+    public void setSignerRole(SignerRole signerRole);
+}

--- a/src/main/java/es/uji/crypto/xades/jxades/security/xml/XAdES/XadesWithExplicitPolicy.java
+++ b/src/main/java/es/uji/crypto/xades/jxades/security/xml/XAdES/XadesWithExplicitPolicy.java
@@ -1,0 +1,7 @@
+package es.uji.crypto.xades.jxades.security.xml.XAdES;
+
+public interface XadesWithExplicitPolicy {
+	
+    public SignaturePolicyIdentifier getSignaturePolicyIdentifier();
+    public void setSignaturePolicyIdentifier(SignaturePolicyIdentifier signaturePolicyIdentifier);    
+}

--- a/src/test/java/es/uji/crypto/xades/jxades/security/xml/BLevelSignatureTest.java
+++ b/src/test/java/es/uji/crypto/xades/jxades/security/xml/BLevelSignatureTest.java
@@ -1,0 +1,68 @@
+package es.uji.crypto.xades.jxades.security.xml;
+
+import java.io.ByteArrayOutputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.security.GeneralSecurityException;
+import java.util.Arrays;
+
+import javax.xml.crypto.MarshalException;
+import javax.xml.crypto.dsig.SignatureMethod;
+import javax.xml.crypto.dsig.TransformException;
+import javax.xml.crypto.dsig.XMLSignatureException;
+import javax.xml.parsers.ParserConfigurationException;
+
+import es.uji.crypto.xades.jxades.security.xml.XAdES.SignaturePolicyIdentifier;
+import es.uji.crypto.xades.jxades.security.xml.XAdES.SignaturePolicyIdentifierImpl;
+import es.uji.crypto.xades.jxades.security.xml.XAdES.SigningCertificateV2Info;
+import es.uji.crypto.xades.jxades.security.xml.XAdES.XAdES;
+import es.uji.crypto.xades.jxades.security.xml.XAdES.XAdES_B_Level;
+import es.uji.crypto.xades.jxades.security.xml.XAdES.XAdES_EPES;
+import es.uji.crypto.xades.jxades.security.xml.XAdES.XMLAdvancedSignature;
+
+import org.junit.Test;
+import org.xml.sax.SAXException;
+
+public class BLevelSignatureTest extends BaseTest
+{
+    @Test
+    public void bLevelDetached() throws FileNotFoundException, IOException, GeneralSecurityException,
+            MarshalException, XMLSignatureException, TransformException,
+            ParserConfigurationException, SAXException
+    {
+        // Default signature options
+        SignatureOptions signatureOptions = getSignatureOptions(
+                "src/test/resources/catcert.p12", "PKCS12", null, "1234", "1234");
+
+        // Build XAdES-EPES signature
+        XMLAdvancedSignature xmlSignature = createXadesBLevel(signatureOptions);
+        xmlSignature.sign(signatureOptions.getCertificate(), signatureOptions.getPrivateKey(),
+                SignatureMethod.RSA_SHA1,
+                Arrays.asList(new Object[] { "http://es.wikipedia.org/wiki/CATCert" }), "S0");
+
+        // Show results
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        showSignature(xmlSignature, bos);
+        System.out.println(new String(bos.toByteArray()));
+
+        // Verify signature
+        verify(xmlSignature);
+
+        OutputStream os = new FileOutputStream("target/out-detached-B_Level.xml");
+        showSignature(xmlSignature, os);
+        os.close();
+    }
+    
+    private static XMLAdvancedSignature createXadesBLevel(SignatureOptions signatureOptions)
+            throws GeneralSecurityException
+    {
+        // Build XAdES-EPES signature
+        XAdES_B_Level xades = (XAdES_B_Level) XAdES.newInstance(XAdES.B_LEVEL);
+        xades.setSigningCertificateV2(signatureOptions.getCertificate(), null);
+        
+        // Enveloped signature
+        return XMLAdvancedSignature.newInstance(xades);
+    }
+}


### PR DESCRIPTION
Cambios necesarios para el soporte de las firmas baseline B-Level por parte de JXAdES. Estos cambios incluyen el agregar el nuevo perfil al listado de perfiles soportados y la implementación correspondiente.

La implementación se ha realizado en base al estándar [ETSI EN 319 132-1 V1.1.1 (2016-04)](https://www.etsi.org/deliver/etsi_en/319100_319199/31913201/01.01.01_60/en_31913201v010101p.pdf) y siguiendo el [último esquema de XAdES 1.3.2](https://uri.etsi.org/01903/v1.3.2/XAdES01903v132-201601.xsd).

El nuevo perfil incluye 3 cambios principales que no estaban soportados por la biblioteca:
- Se debe utilizar el elemento SigningCertificateV2 en lugar de SigningCertificate.
- Se debe utilizar el elemento SignerRoleV2 en lugar de SignerRole.
- Se debe utilizar el elemento SignatureProductionPlaceV2 en lugar de SignatureProductionPlace.
